### PR TITLE
Improve compatibility with composer based installations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "moc/message-queue",
+    "name": "moc/moc-message-queue",
     "type": "typo3-cms-extension",
     "description": "Extension for maintaining a central message queue. Bundles with a beanstalk implementation of the messaging layer.",
     "homepage": "https://github.com/mocdk/moc_message_queue",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "moc/message-queue",
+    "type": "typo3-cms-extension",
+    "description": "Extension for maintaining a central message queue. Bundles with a beanstalk implementation of the messaging layer.",
+    "homepage": "https://github.com/mocdk/moc_message_queue",
+    "license": ["GPL-2.0+"],
+    "version": "1.1.0",
+    "require": {
+        "typo3/cms-core": ">=6.2.1,<8.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "MOC\\MocMessageQueue\\": "Classes"
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": ["GPL-2.0+"],
     "version": "1.1.0",
     "require": {
-        "typo3/cms-core": ">=6.2.1,<8.0"
+        "typo3/cms-core": ">=6.2,<8.0"
     },
     "autoload": {
         "psr-4": {

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -13,7 +13,7 @@ if ($config['message_queue_implementation'] === 'Beanstalk' && $config['disable_
 	Pheanstalk_ClassLoader::register($pheanstalkClassRoot);
 }
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = 'Moc\MocMessageQueue\Command\QueueWorkerCommandController';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['extbase']['commandControllers'][] = 'MOC\MocMessageQueue\Command\QueueWorkerCommandController';
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup('
 config.tx_extbase {


### PR DESCRIPTION
These change adds a composer.json file to allow installation / class auto loading in composer based installations. Additionally, a typo in a class name in ext_localconf.php has been fixed.
